### PR TITLE
Feature/task cache - adds caching to all tasks and commands.

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -12,7 +12,6 @@
     "reporter": [
       "text-summary",
       "html",
-      "lcov",
       "json"
     ],
     "all": true

--- a/.nycrc
+++ b/.nycrc
@@ -9,16 +9,11 @@
     "extension": [
         ".ts"
     ],
-    "require": [
-        "ts-node/register"
-    ],
     "reporter": [
       "text-summary",
       "html",
       "lcov",
       "json"
     ],
-    "sourceMap": false,
-    "instrument": true,
     "all": true
 }

--- a/ava.config.js
+++ b/ava.config.js
@@ -5,6 +5,8 @@ export default {
     sources: [
         "src/**/*.ts"
     ],
+    cache: true,
+    compileEnhancements: false,
     extensions: ['ts'],
     require: [
         'ts-node/register'

--- a/docs/tests-and-coverage.md
+++ b/docs/tests-and-coverage.md
@@ -1,0 +1,31 @@
+Comprehensive Tests and Coverage
+================================
+
+Writing tests, and generating useful coverage, for your things are pretty important.
+Here are some tips.
+
+## Using NYC
+`istanbul-merge` can be used for collecting the output from your `nyc` based tests.
+```
+istanbul-merge --out .nyc_output/raw.json packages/node_modules/**/.nyc_output/*.json && nyc report --reporter=lcov --reporter=html --reporter=text-summary
+```
+
+## Collecting Test results
+Some tools, like circle-ci, require all test results to be stored under a specific folder.  It may be easiest to have specific tasks designed to output these to a specific directory:
+
+**monorepository package.json**
+```
+"scripts": {
+    "test-ci": "mister do-all !test-ci",
+    "coverage-ci": "istanbul-merge --out .nyc_output/raw.json packages/node_modules/**/.nyc_output/*.json && nyc report --reporter=lcov --reporter=html --reporter=text-summary"
+}
+```
+
+**package package.json**
+```
+"scripts": {
+    "test-ci": "ava --tap | tap-xunit > $MISTER_ROOT/reports/$MISTER_PACKAGE/xunit.xml && nyc ava"
+}
+```
+
+This should give you a top-level view of coverage and test results for your entire set of packages.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2176,12 +2176,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2196,17 +2198,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2323,7 +2328,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2335,6 +2341,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2349,6 +2356,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2356,12 +2364,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2380,6 +2390,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2460,7 +2471,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2472,6 +2484,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2593,6 +2606,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -491,9 +491,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
-      "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA==",
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.2.tgz",
+      "integrity": "sha512-XubfQDIg88PGJ7netQPf3QOKHF7Xht4WXGtg5W7cGBeQs9ETbYKwfchR9o+tRRA9iLTQ7nAre85M205JbYsjJA==",
       "dev": true
     },
     "@types/rimraf": {
@@ -505,6 +505,11 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
+    },
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -671,6 +676,11 @@
       "version": "0.11.5",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
       "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
+    },
+    "async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
       "version": "1.0.1",
@@ -2951,13 +2961,6 @@
       "integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
       "requires": {
         "async": "~1.5"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        }
       }
     },
     "hosted-git-info": {
@@ -4195,11 +4198,6 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -4243,9 +4241,9 @@
       }
     },
     "needle": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.3.tgz",
-      "integrity": "sha512-GPL22d/U9cai87FcCPO6e+MT3vyHS2j+zwotakDc7kE2DtUAqFKMXLJCTtRp+5S75vXIwQPvIxkvlctxf9q4gQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
       "requires": {
         "debug": "^2.1.2",
         "iconv-lite": "^0.4.4",
@@ -5538,9 +5536,9 @@
       }
     },
     "opn": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
-      "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.4.0.tgz",
+      "integrity": "sha512-YF9MNdVy/0qvJvDtunAOzFw9iasOQHpVthTCvGzxt61Il64AYSGdK+rYwld7NAfk9qJ7dt+hymBNSc9LNYS+Sw==",
       "requires": {
         "is-wsl": "^1.1.0"
       }
@@ -6764,9 +6762,9 @@
       }
     },
     "snyk": {
-      "version": "1.96.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.96.0.tgz",
-      "integrity": "sha512-WiO/R7dY4qu2SdCHHgPz7x3xrjrICOz1ZNNzhU8KIyhHAt/cSTA631xSxmGKLS2dRFzCVxYAGUuvFG84oBy/ag==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.99.0.tgz",
+      "integrity": "sha512-HyvTj7Tap3PLNXN8tXQChL4+Y32TDTYh2Oklp2/5GLPeSlxv/VOBWXwEy/JowwopxcrJ8P8p3px6hSyOoSuvqw==",
       "requires": {
         "abbrev": "^1.1.1",
         "ansi-escapes": "^3.1.0",
@@ -6776,7 +6774,7 @@
         "hasbin": "^1.2.3",
         "inquirer": "^3.0.0",
         "lodash": "^4.17.5",
-        "needle": "^2.0.1",
+        "needle": "^2.2.4",
         "opn": "^5.2.0",
         "os-name": "^2.0.1",
         "proxy-agent": "^2.0.0",
@@ -6786,19 +6784,20 @@
         "snyk-config": "2.2.0",
         "snyk-docker-plugin": "1.11.0",
         "snyk-go-plugin": "1.5.2",
-        "snyk-gradle-plugin": "1.3.1",
+        "snyk-gradle-plugin": "2.0.0",
         "snyk-module": "1.8.2",
-        "snyk-mvn-plugin": "1.2.2",
-        "snyk-nodejs-lockfile-parser": "1.4.1",
+        "snyk-mvn-plugin": "2.0.0",
+        "snyk-nodejs-lockfile-parser": "1.5.1",
         "snyk-nuget-plugin": "1.6.5",
         "snyk-php-plugin": "1.5.1",
         "snyk-policy": "1.12.0",
         "snyk-python-plugin": "1.8.1",
         "snyk-resolve": "1.0.1",
         "snyk-resolve-deps": "3.1.0",
-        "snyk-sbt-plugin": "1.3.2",
+        "snyk-sbt-plugin": "2.0.0",
         "snyk-tree": "^1.0.0",
         "snyk-try-require": "1.3.1",
+        "source-map-support": "^0.5.9",
         "tempfile": "^2.0.0",
         "then-fs": "^2.0.0",
         "undefsafe": "^2.0.0",
@@ -6835,9 +6834,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-1.3.1.tgz",
-      "integrity": "sha512-WJQuJFihqvnOqtV8Psl8W2/XxluSxB/tffHmGXy5b2C2VO56WmEvn1JHTcmvkRBP1KjPtwccMc1e7WeOVT3saQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.0.0.tgz",
+      "integrity": "sha512-X59ADEscMfZJpOUUGLit4OSlJoK2vuvqfDYPtT7BZXj/Br+/m20bE6Y38YhYjqUH5zj96KSRpmqRp8qsz7lCdg==",
       "requires": {
         "clone-deep": "^0.3.0"
       }
@@ -6852,15 +6851,16 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-1.2.2.tgz",
-      "integrity": "sha512-KfT7JZWIxYbLkqhidUyOMNeK/iTwNeHYwqNtycMS3S4i9NfbfrMl73IesxNyJQeGgZ79ms5sg7psqAQj29uZIA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.0.0.tgz",
+      "integrity": "sha512-9jAhZhv+7YcqtoQYCYlgMoxK+dWBKlk+wkX27Ebg3vNddNop9q5jZitRXTjsXwfSUZHRt+Ptw1f8vei9kjzZVg=="
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.4.1.tgz",
-      "integrity": "sha512-xjkf1BHk7HQlp4ABIWPtEvAOAvWhwMtJ7ElQVUvKBHPVHjMEz3mucBRfrtpuyDBJ3DaBlN8Wiw+kcEinX6f09w==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.5.1.tgz",
+      "integrity": "sha512-rfFcW+ZrOEH3NxufUCpMBpNLSb4BPOxLbAM6MoRqfYH5DhSdTHsecwRDf1gU6XzQok/9Koav+1qtP8+welJC2A==",
       "requires": {
+        "@yarnpkg/lockfile": "^1.0.2",
         "lodash": "4.17.10",
         "path": "0.12.7",
         "source-map-support": "^0.5.7"
@@ -6942,9 +6942,9 @@
       }
     },
     "snyk-sbt-plugin": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-1.3.2.tgz",
-      "integrity": "sha512-Pm6G8emW4mDg9hflY0gsdFV5JgR8pHa8D1vCZGJMVSRuGrc64CEg8I1D6977lGoKDwJGePwi4CTcluwj7cNsxQ=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.0.0.tgz",
+      "integrity": "sha512-bOUqsQ1Lysnwfnvf4QQIBfC0M0ZVuhlshTKd7pNwgAJ41YEPJNrPEpzOePl/HfKtwilEEwHh5YHvjYGegEKx0A=="
     },
     "snyk-tree": {
       "version": "1.0.0",
@@ -7490,9 +7490,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-      "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
+      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
       "dev": true
     },
     "uid2": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7381,6 +7381,12 @@
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.3.tgz",
       "integrity": "sha512-O7L5hhSQHxuufWUdcTRPfuTh3phKfAZ/dqfxZFoxPCj2RYmpaSGLEIs016FCXItQwNr08yefUB5TSjzRYnajTA=="
     },
+    "transit-js": {
+      "version": "0.8.861",
+      "resolved": "https://registry.npmjs.org/transit-js/-/transit-js-0.8.861.tgz",
+      "integrity": "sha512-4O9OrYPZw6C0M5gMTvaeOp+xYz6EF79JsyxIvqXHlt+pisSrioJWFOE80N8aCPoJLcNaXF442RZrVtdmd4wkDQ==",
+      "dev": true
+    },
     "traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -806,7 +806,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -1964,7 +1964,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "^0.4.0",
@@ -2706,7 +2706,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2982,7 +2982,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -3283,7 +3283,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
     },
     "is-observable": {
@@ -4093,7 +4093,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -4238,7 +4238,7 @@
         },
         "yargs": {
           "version": "3.32.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "requires": {
             "camelcase": "^2.0.1",
@@ -6003,7 +6003,7 @@
     },
     "proxy-agent": {
       "version": "2.3.1",
-      "resolved": "http://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
       "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
       "requires": {
         "agent-base": "^4.2.0",
@@ -6198,7 +6198,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -7352,7 +7352,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -7887,7 +7887,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -444,13 +444,10 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.1.tgz",
-      "integrity": "sha512-7oX6PXMulvdN37h88dvlvRyu61GYZau40fL4wEZvPEHvrjpJc3lDv6xDM5n4Z0StufUVB5nDvVZUM+jZHdMOOQ==",
-      "dev": true,
-      "requires": {
-        "array-from": "^2.1.1"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.2.tgz",
+      "integrity": "sha512-ZwTHAlC9akprWDinwEPD4kOuwaYZlyMwVJIANsKNC3QVp0AHB04m7RnB4eqeWfgmxw8MGTzS9uMaw93Z3QcZbw==",
+      "dev": true
     },
     "@types/cross-spawn": {
       "version": "6.0.0",
@@ -491,9 +488,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.11.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.3.tgz",
-      "integrity": "sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==",
+      "version": "10.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.7.tgz",
+      "integrity": "sha512-yOxFfkN9xUFLyvWaeYj90mlqTJ41CsQzWKS3gXdOMOyPVacUsymejKxJ4/pMW7exouubuEeZLJawGgcNGYlTeg==",
       "dev": true
     },
     "@types/rimraf": {
@@ -679,7 +676,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
@@ -1310,7 +1307,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -1964,7 +1961,7 @@
     },
     "external-editor": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
       "requires": {
         "chardet": "^0.4.0",
@@ -2706,7 +2703,7 @@
         },
         "readable-stream": {
           "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2982,7 +2979,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
@@ -3727,8 +3724,7 @@
     "lodash.clone": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
-      "dev": true
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -4230,7 +4226,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4238,7 +4234,7 @@
         },
         "yargs": {
           "version": "3.32.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "requires": {
             "camelcase": "^2.0.1",
@@ -6003,7 +5999,7 @@
     },
     "proxy-agent": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/proxy-agent/-/proxy-agent-2.3.1.tgz",
       "integrity": "sha512-CNKuhC1jVtm8KJYFTS2ZRO71VCBx3QSA92So/e6NrY6GoJonkx3Irnk4047EsCcswczwqAekRj3s8qLRGahSKg==",
       "requires": {
         "agent-base": "^4.2.0",
@@ -6546,7 +6542,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
             "is-buffer": "^1.0.2"
@@ -6573,17 +6569,17 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.4.tgz",
-      "integrity": "sha512-NIaR56Z1mefuRBXYrf4otqBxkWiKveX+fvqs3HzFq2b07HcgpkMgIwmQM/owNjNFAHkx0kJXW+Q0mDthiuslXw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.5.tgz",
+      "integrity": "sha512-xgoZ2gKjyVRcF08RrIQc+srnSyY1JDJtxu3Nsz07j1ffjgXoY6uPLf/qja6nDBZgzYYEovVkFryw2+KiZz11xQ==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
         "@sinonjs/formatio": "^3.0.0",
-        "@sinonjs/samsam": "^2.1.1",
+        "@sinonjs/samsam": "^2.1.2",
         "diff": "^3.5.0",
         "lodash.get": "^4.4.2",
-        "lolex": "^2.7.4",
+        "lolex": "^2.7.5",
         "nise": "^1.4.5",
         "supports-color": "^5.5.0",
         "type-detect": "^4.0.8"
@@ -6774,9 +6770,9 @@
       }
     },
     "snyk": {
-      "version": "1.99.1",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.99.1.tgz",
-      "integrity": "sha512-vN2jUGwHPHAbqqOeZQsBrnWgTvuCnbxsP8i9BIaqZxINeKbuBOS1t5Kg9KMMCRJyqqCB/y76PQSdoqavh4yxkg==",
+      "version": "1.103.1",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.103.1.tgz",
+      "integrity": "sha512-VME1ty5PfMvK8cziXJAaH8EYbdXOXCQn/IelNkCdWCeldT38HLG+ZWkigoGNHrhPmbyTaxi9qa+6U+VTAuylMg==",
       "requires": {
         "abbrev": "^1.1.1",
         "ansi-escapes": "^3.1.0",
@@ -6794,18 +6790,18 @@
         "recursive-readdir": "^2.2.2",
         "semver": "^5.5.0",
         "snyk-config": "2.2.0",
-        "snyk-docker-plugin": "1.11.0",
+        "snyk-docker-plugin": "1.12.0",
         "snyk-go-plugin": "1.5.2",
-        "snyk-gradle-plugin": "2.0.1",
+        "snyk-gradle-plugin": "2.1.0",
         "snyk-module": "1.8.2",
         "snyk-mvn-plugin": "2.0.0",
         "snyk-nodejs-lockfile-parser": "1.5.1",
         "snyk-nuget-plugin": "1.6.5",
         "snyk-php-plugin": "1.5.1",
         "snyk-policy": "1.12.0",
-        "snyk-python-plugin": "1.8.1",
+        "snyk-python-plugin": "1.8.2",
         "snyk-resolve": "1.0.1",
-        "snyk-resolve-deps": "3.1.0",
+        "snyk-resolve-deps": "4.0.1",
         "snyk-sbt-plugin": "2.0.0",
         "snyk-tree": "^1.0.0",
         "snyk-try-require": "1.3.1",
@@ -6827,9 +6823,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.11.0.tgz",
-      "integrity": "sha512-rJrSj4FfGtaFGNybWTb0bULEqoQEeZfZBpGoDumiXsGqoSWf61Tr1V/Ck9NGcmHWNEVsLZLcE9CXp6Y6Kbo8qA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-1.12.0.tgz",
+      "integrity": "sha512-QqKq2bGdnf1L2PNGQrHoqcoaV/PIlJv1qjKIzwA93gfhToKGkgJ31oPXwfef/l9N+ui0Y44c4POBHFbFf8PlJw==",
       "requires": {
         "debug": "^3",
         "tslib": "^1"
@@ -6846,9 +6842,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.0.1.tgz",
-      "integrity": "sha512-dL9MRlwmDP4OmOk4b61pMqvbu8gG+HVCBTryBEU+vkvjloX0lslKvA5NTUPAM2M8SShnOic54cSegGQChBhYHw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.1.0.tgz",
+      "integrity": "sha512-9gYJluomFZ5kaww5FoBvp4zUIsr27pEJ12jQJaVf0FJ0BmyYHmbCoxvHdqjCSYS2fVtF+fmPnvw0XKQOIwA1SA==",
       "requires": {
         "clone-deep": "^0.3.0"
       }
@@ -6916,9 +6912,9 @@
       }
     },
     "snyk-python-plugin": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.8.1.tgz",
-      "integrity": "sha512-DsUBkQZiPlXGkwzhxxEo2Tvfq6XhygWQThWM0yRBythi9M5n8UimZEwdkBHPj7xKC1clsB8boM3+sT/E1x6XGA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/snyk-python-plugin/-/snyk-python-plugin-1.8.2.tgz",
+      "integrity": "sha512-LBvjztnXarSHKyhivzM567icOOLOB98I7S9EEnjepuG+EZ0jiZzqOEMVRmzuYi+hRq3Cwh0hhjkwgJAQpKDz+g==",
       "requires": {
         "tmp": "0.0.33"
       }
@@ -6933,19 +6929,20 @@
       }
     },
     "snyk-resolve-deps": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-3.1.0.tgz",
-      "integrity": "sha512-YVAelR+dTpqLgfk6lf6WgOlw+MGmGI0r3/Dny8tUbJJ9uVTHTRAOdZCbUyTFqJG7oEmEZxUwmfjqgAuniYwx8Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/snyk-resolve-deps/-/snyk-resolve-deps-4.0.1.tgz",
+      "integrity": "sha512-gieaYoOuJLXzUmDDKfQJAqfwaxa43KmSqN2d9abRfgMXnLlX9IqyoZ1wqZMbd3WN7tsHSkpWvVwc4FHdQEkUKA==",
       "requires": {
         "ansicolors": "^0.3.2",
-        "debug": "^3.1.0",
+        "debug": "^3.2.5",
         "lodash.assign": "^4.2.0",
         "lodash.assignin": "^4.2.0",
+        "lodash.clone": "^4.5.0",
         "lodash.flatten": "^4.4.0",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "lru-cache": "^4.0.0",
-        "semver": "^5.1.0",
+        "semver": "^5.5.1",
         "snyk-module": "^1.6.0",
         "snyk-resolve": "^1.0.0",
         "snyk-tree": "^1.0.0",
@@ -7338,7 +7335,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
@@ -7352,7 +7349,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -7545,9 +7542,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
-      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.2.tgz",
+      "integrity": "sha512-gOoGJWbNnFAfP9FlrSV63LYD5DJqYJHG5ky1kOXSl3pCImn4rqWy/flyq1BRd4iChQsoCqjbQaqtmXO4yCVPCA==",
       "dev": true
     },
     "uid2": {
@@ -7958,7 +7955,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xregexp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mister",
-  "version": "1.4.1",
+  "version": "1.5.0-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -491,9 +491,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.11.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.2.tgz",
-      "integrity": "sha512-XubfQDIg88PGJ7netQPf3QOKHF7Xht4WXGtg5W7cGBeQs9ETbYKwfchR9o+tRRA9iLTQ7nAre85M205JbYsjJA==",
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.11.3.tgz",
+      "integrity": "sha512-3AvcEJAh9EMatxs+OxAlvAEs7OTy6AG94mcH1iqyVDwVVndekLxzwkWQ/Z4SDbY6GO2oyUXyWW8tQ4rENSSQVQ==",
       "dev": true
     },
     "@types/rimraf": {
@@ -679,7 +679,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
@@ -1310,7 +1310,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4218,7 +4218,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6534,7 +6534,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
             "is-buffer": "^1.0.2"
@@ -6762,9 +6762,9 @@
       }
     },
     "snyk": {
-      "version": "1.99.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.99.0.tgz",
-      "integrity": "sha512-HyvTj7Tap3PLNXN8tXQChL4+Y32TDTYh2Oklp2/5GLPeSlxv/VOBWXwEy/JowwopxcrJ8P8p3px6hSyOoSuvqw==",
+      "version": "1.99.1",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.99.1.tgz",
+      "integrity": "sha512-vN2jUGwHPHAbqqOeZQsBrnWgTvuCnbxsP8i9BIaqZxINeKbuBOS1t5Kg9KMMCRJyqqCB/y76PQSdoqavh4yxkg==",
       "requires": {
         "abbrev": "^1.1.1",
         "ansi-escapes": "^3.1.0",
@@ -6784,7 +6784,7 @@
         "snyk-config": "2.2.0",
         "snyk-docker-plugin": "1.11.0",
         "snyk-go-plugin": "1.5.2",
-        "snyk-gradle-plugin": "2.0.0",
+        "snyk-gradle-plugin": "2.0.1",
         "snyk-module": "1.8.2",
         "snyk-mvn-plugin": "2.0.0",
         "snyk-nodejs-lockfile-parser": "1.5.1",
@@ -6834,9 +6834,9 @@
       }
     },
     "snyk-gradle-plugin": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.0.0.tgz",
-      "integrity": "sha512-X59ADEscMfZJpOUUGLit4OSlJoK2vuvqfDYPtT7BZXj/Br+/m20bE6Y38YhYjqUH5zj96KSRpmqRp8qsz7lCdg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/snyk-gradle-plugin/-/snyk-gradle-plugin-2.0.1.tgz",
+      "integrity": "sha512-dL9MRlwmDP4OmOk4b61pMqvbu8gG+HVCBTryBEU+vkvjloX0lslKvA5NTUPAM2M8SShnOic54cSegGQChBhYHw==",
       "requires": {
         "clone-deep": "^0.3.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -679,7 +679,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "async-each": {
@@ -1310,7 +1310,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -1713,6 +1713,12 @@
         "is-obj": "^1.0.0"
       }
     },
+    "duplexer": {
+      "version": "0.1.1",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+      "dev": true
+    },
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -1859,6 +1865,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "events-to-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/events-to-array/-/events-to-array-1.1.2.tgz",
+      "integrity": "sha1-LUH1Y+H+QA7Uli/hpNXGp1Od9/Y=",
+      "dev": true
     },
     "execa": {
       "version": "0.10.0",
@@ -4218,7 +4230,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -6534,7 +6546,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
             "is-buffer": "^1.0.2"
@@ -7182,6 +7194,49 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
       "dev": true
+    },
+    "tap-parser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-1.2.2.tgz",
+      "integrity": "sha1-Xi9pcGEfB5x8+FfeHceqG0gN56U=",
+      "dev": true,
+      "requires": {
+        "events-to-array": "^1.0.1",
+        "inherits": "~2.0.1",
+        "js-yaml": "^3.2.7",
+        "readable-stream": "^2"
+      }
+    },
+    "tap-xunit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tap-xunit/-/tap-xunit-2.3.0.tgz",
+      "integrity": "sha512-YVsURNvn1wfVUWb5wjansxhfbfeo2hOBTUbVgZoaMO8lyZzpiSi9IiZTZ7JG56m6A49LeWjfJIx/SnAre41V/A==",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "minimist": "~1.2.0",
+        "tap-parser": "~1.2.2",
+        "through2": "~2.0.0",
+        "xmlbuilder": "~4.2.0",
+        "xtend": "~4.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.0.0"
+          }
+        }
+      }
     },
     "tar": {
       "version": "4.4.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mister",
-  "version": "1.4.1",
+  "version": "1.5.0-alpha.1",
   "description": "",
   "main": "dist/index.js",
   "bin": {
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.11.2",
+    "@types/node": "^10.11.3",
     "@types/rimraf": "^2.0.2",
     "ava": "^1.0.0-beta.8",
     "cross-env": "^5.2.0",
@@ -46,7 +46,7 @@
     "glob": "^7.1.3",
     "glob-gitignore": "^1.0.9",
     "mkdirp": "^0.5.1",
-    "snyk": "^1.99.0",
+    "snyk": "^1.99.1",
     "tar": "^4.4.6",
     "tar-to-zip": "^2.0.0",
     "yargs": "^12.0.2"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "prettier": "^1.14.3",
     "rimraf": "^2.6.2",
     "sinon": "^6.3.4",
+    "transit-js": "^0.8.861",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.11.3",
+    "@types/node": "^10.11.7",
     "@types/rimraf": "^2.0.2",
     "ava": "^1.0.0-beta.8",
     "cross-env": "^5.2.0",
@@ -33,13 +33,13 @@
     "nyc": "^13.0.1",
     "prettier": "^1.14.3",
     "rimraf": "^2.6.2",
-    "sinon": "^6.3.4",
+    "sinon": "^6.3.5",
     "tap-xunit": "^2.3.0",
     "transit-js": "^0.8.861",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
-    "typescript": "^3.1.1",
+    "typescript": "^3.1.2",
     "unzip": "^0.1.11"
   },
   "dependencies": {
@@ -49,7 +49,7 @@
     "glob": "^7.1.3",
     "glob-gitignore": "^1.0.9",
     "mkdirp": "^0.5.1",
-    "snyk": "^1.99.1",
+    "snyk": "^1.103.1",
     "tar": "^4.4.6",
     "tar-to-zip": "^2.0.0",
     "yargs": "^12.0.2"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@types/cross-spawn": "^6.0.0",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.10.1",
+    "@types/node": "^10.11.2",
     "@types/rimraf": "^2.0.2",
     "ava": "^1.0.0-beta.8",
     "cross-env": "^5.2.0",
@@ -36,7 +36,7 @@
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
-    "typescript": "^3.0.3",
+    "typescript": "^3.1.1",
     "unzip": "^0.1.11"
   },
   "dependencies": {
@@ -46,7 +46,7 @@
     "glob": "^7.1.3",
     "glob-gitignore": "^1.0.9",
     "mkdirp": "^0.5.1",
-    "snyk": "^1.96.0",
+    "snyk": "^1.99.0",
     "tar": "^4.4.6",
     "tar-to-zip": "^2.0.0",
     "yargs": "^12.0.2"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "build": "rimraf dist && tsc -p .",
     "test": "nyc ava",
+    "test:ci": "ava --reset-cache && npm run test && npm run test:xunit",
+    "test:xunit": "ava --tap | tap-xunit > coverage/xunit.xml",
     "lint": "tslint -p . --fix ",
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect"
@@ -32,6 +34,7 @@
     "prettier": "^1.14.3",
     "rimraf": "^2.6.2",
     "sinon": "^6.3.4",
+    "tap-xunit": "^2.3.0",
     "transit-js": "^0.8.861",
     "ts-node": "^7.0.1",
     "tslint": "^5.11.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,13 +18,13 @@ require('yargs') // tslint:disable-line
     .option('v', {
         alias: 'verbose',
         count: true,
+        default: 1,
         description: 'Enable Verbose messaging.  -v to see basic output, -vv to see detailed outpur, -vvv to se subprocess output',
-        default: 1
     })
     .option('q', {
         alias: 'quiet',
+        default: 'false',
         type: 'boolean',
-        default: 'false'
     })
     .option('package-prefix', {
         default: 'packages',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,12 @@ require('yargs') // tslint:disable-line
         alias: 'verbose',
         count: true,
         description: 'Enable Verbose messaging.  -v to see basic output, -vv to see detailed outpur, -vvv to se subprocess output',
+        default: 1
+    })
+    .option('q', {
+        alias: 'quiet',
+        type: 'boolean',
+        default: 'false'
     })
     .option('package-prefix', {
         default: 'packages',

--- a/src/commands/__tests__/do-all/do-all.spec.ts
+++ b/src/commands/__tests__/do-all/do-all.spec.ts
@@ -23,7 +23,8 @@ import App from '../../../lib/App';
 
 test('command: do-all - runs three commands' , (t) => {
     const argv = {
-        tasks: ['test1', 'test2', 'test3'],
+        tasks: ['!test1', '!test2', '!test3'],
+        quiet: true
     };
     const app = new App(argv, {writeCache: false});
     const spy = sinon.spy(app, 'doTask');

--- a/src/commands/__tests__/do-all/fixtures/.mister/cache.json
+++ b/src/commands/__tests__/do-all/fixtures/.mister/cache.json
@@ -1,0 +1,55 @@
+{
+  "packages": {
+    "package2": {
+      "dependencies": {},
+      "taskTimestamps": {
+        "test3": "2018-10-11T05:33:53.145Z"
+      }
+    },
+    "package1": {
+      "dependencies": {},
+      "taskTimestamps": {
+        "test1": "2018-10-11T05:33:55.980Z",
+        "test3": "2018-10-11T05:33:58.423Z"
+      }
+    },
+    "@test/package3": {
+      "dependencies": {
+        "package1": {
+          "taskTimestamps": {
+            "test2": "2018-10-11T05:34:00.214Z",
+            "test3": "2018-10-11T05:34:02.485Z"
+          }
+        },
+        "package2": {
+          "taskTimestamps": {
+            "test2": "2018-10-11T05:34:00.214Z",
+            "test3": "2018-10-11T05:34:02.485Z"
+          }
+        }
+      },
+      "taskTimestamps": {
+        "test2": "2018-10-11T05:34:00.214Z",
+        "test3": "2018-10-11T05:34:02.485Z"
+      }
+    },
+    "@test/package4": {
+      "dependencies": {
+        "package2": {
+          "taskTimestamps": {
+            "test3": "2018-10-11T05:34:04.336Z"
+          }
+        },
+        "@test/package3": {
+          "taskTimestamps": {
+            "test3": "2018-10-11T05:34:04.336Z"
+          }
+        }
+      },
+      "taskTimestamps": {
+        "test3": "2018-10-11T05:34:04.336Z"
+      }
+    }
+  },
+  "version": "1.0.1"
+}

--- a/src/commands/__tests__/do/do-failures.spec.ts
+++ b/src/commands/__tests__/do/do-failures.spec.ts
@@ -22,7 +22,8 @@ test('command: do - should error', (t) => {
     const argv = {
         packages: ['package1', '@test/package3'],
         stdio: false,
-        tasks: ['fails1', 'test2']
+        tasks: ['!fails1', '!test2'],
+        quiet: true
     };
 
     const app = new App(argv, {writeCache: false});

--- a/src/commands/__tests__/do/do-with-dependencies.spec.ts
+++ b/src/commands/__tests__/do/do-with-dependencies.spec.ts
@@ -23,8 +23,9 @@ test.after(() => {
 test('command: do --with-dependencies', (t) => {
     const argv = {
         'packages': ['@test/package4'],
-        'tasks': ['test3'],
+        'tasks': ['!test3'],
         'with-dependencies': true,
+        quiet: true
     };
     const app = new App(argv, {writeCache: false});
     const spy = sinon.spy(app, 'doTask');

--- a/src/commands/__tests__/do/do.spec.ts
+++ b/src/commands/__tests__/do/do.spec.ts
@@ -23,7 +23,8 @@ test.after(() => {
 test('command: do - runs two commands on two packages' , async (t) => {
     const argv = {
         packages: ['package1', '@test/package3'],
-        tasks: ['test1', 'test2']
+        tasks: ['!test1', '!test2'],
+        quiet: true
     };
     const app = new App(argv, {writeCache: false});
     const spy = sinon.spy(app, 'doTask');
@@ -38,7 +39,7 @@ test('command: do - runs two commands on two packages' , async (t) => {
 test('command: do - runs two commands given four packages but only two matching tasks' , async (t) => {
     const argv = {
         packages: ['package1', 'package2', '@test/package3', '@test/package4'],
-        tasks: ['test1', 'test2']
+        tasks: ['!test1', '!test2']
     };
     const app = new App(argv, {writeCache: false});
     const spy = sinon.spy(app, 'doTask');

--- a/src/commands/__tests__/do/fixtures/.mister/cache.json
+++ b/src/commands/__tests__/do/fixtures/.mister/cache.json
@@ -1,0 +1,54 @@
+{
+  "packages": {
+    "package2": {
+      "dependencies": {},
+      "taskTimestamps": {
+        "test3": "2018-10-11T05:33:53.366Z"
+      }
+    },
+    "@test/package3": {
+      "dependencies": {
+        "package1": {
+          "taskTimestamps": {
+            "test3": "2018-10-11T05:33:56.211Z",
+            "test2": "2018-10-11T05:06:19.745Z"
+          }
+        },
+        "package2": {
+          "taskTimestamps": {
+            "test3": "2018-10-11T05:33:56.211Z",
+            "test2": "2018-10-11T05:06:19.745Z"
+          }
+        }
+      },
+      "taskTimestamps": {
+        "test3": "2018-10-11T05:33:56.211Z",
+        "test2": "2018-10-11T05:06:19.745Z"
+      }
+    },
+    "@test/package4": {
+      "dependencies": {
+        "package2": {
+          "taskTimestamps": {
+            "test3": "2018-10-11T05:33:58.841Z"
+          }
+        },
+        "@test/package3": {
+          "taskTimestamps": {
+            "test3": "2018-10-11T05:33:58.841Z"
+          }
+        }
+      },
+      "taskTimestamps": {
+        "test3": "2018-10-11T05:33:58.841Z"
+      }
+    },
+    "package1": {
+      "dependencies": {},
+      "taskTimestamps": {
+        "test1": "2018-10-11T05:29:39.094Z"
+      }
+    }
+  },
+  "version": "1.0.1"
+}

--- a/src/commands/__tests__/pack/pack.spec.ts
+++ b/src/commands/__tests__/pack/pack.spec.ts
@@ -36,6 +36,7 @@ test('command: pack', (t) => {
     const args = {
         'debug-persist-package-json': false,
         'packages': ['@test-server/api'],
+        quiet: true
     };
     return runProcess('npm', ['install', '--skip-package-lock'], {
         cwd: path.join(CWD),

--- a/src/commands/__tests__/zip/zip.spec.ts
+++ b/src/commands/__tests__/zip/zip.spec.ts
@@ -39,6 +39,7 @@ test.beforeEach(() => {
 test('command: zip', (t) => {
     const args = {
         packages: ['@test-server/api'],
+        quiet: true
     };
     return runProcess('npm', ['install', '--skip-package-lock'], {
         cwd: path.join(CWD),

--- a/src/commands/do-all.ts
+++ b/src/commands/do-all.ts
@@ -2,8 +2,8 @@
 import App from '../lib/App';
 
 export const command = 'do-all [tasks...]';
-export const describe = 'Runs npm tasks on all packages';
-export const usage = 'mister do-all clean test build';
+export const describe = 'Runs npm tasks on all packages.  Negate a task name to skip checking for previous invocations.';
+export const usage = 'mister do-all !clean !test build';
 
 export function handler(argv) {
     const app = new App(argv);

--- a/src/commands/do.ts
+++ b/src/commands/do.ts
@@ -3,9 +3,9 @@ import { Argv } from 'yargs';
 import App from '../lib/App';
 
 export const command = 'do [packages...]';
-export const describe = 'Runs npm tasks on packages';
+export const describe = 'Runs npm tasks on packages.  Negate a task name to skip checking for previous invocations of that task';
 /* istanbul ignore file */
-export const usage = 'mister do package1 package2 --tasks=clean test build';
+export const usage = 'mister do package1 package2 --tasks=clean !test build';
 
 export const builder = (yargs: Argv) => yargs.option('all', {
     default: false,

--- a/src/lib/App/App.ts
+++ b/src/lib/App/App.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import { sync as rimraf } from 'rimraf';
 import { Argv } from 'yargs';
 
+import normalizeArgs from '../normalize-args';
 import moveFile from '../move-file';
 import wrap from '../output/wrap';
 import runProcess from '../run-process';
@@ -28,7 +29,7 @@ export default class App {
     private packageCache: PackageCache;
 
     constructor(args: Argv, options?: AppOptions) {
-        this.args = args;
+        this.args = normalizeArgs(args);
         this.verbosity = this.args.verbose || 0;
         this.writeCache = options && options.writeCache || true;
         this.checkCommandCache = !!args.cache;

--- a/src/lib/App/App.ts
+++ b/src/lib/App/App.ts
@@ -97,10 +97,6 @@ export default class App {
                 this.packageManager.writePackagePjson(this.args, packageName, newPjson);
                 rimraf(path.join(packageDir, 'node_modules'));
 
-                if (this.verbosity >= 1) {
-                    /* tslint:disable-next-line */
-                    console.log(wrap('[]', 'mister pack'), packageName);
-                }
 
                 await this.packageManager.preparePackage(packageName);
                 await this.packageManager.runPackageProcess(this.args, packageName, 'npm', ['install', '--production', '--skip-package-lock']);
@@ -117,7 +113,7 @@ export default class App {
 
                 if (this.verbosity >= 1) {
                     /* tslint:disable-next-line */
-                    console.log(wrap('[]', 'mister pack'), 'created', chalk.bold.green(distFileLocation));
+                    console.log(wrap('[]', packageName), 'created', chalk.bold.green(distFileLocation));
                 }
                 this.packageCache.writeTimestampForCommand(packageName, 'pack')
 
@@ -125,7 +121,7 @@ export default class App {
                 rimraf(path.join(packageDir, 'node_modules'));
             }).catch((e: Error) => {
                 /* tslint:disable-next-line */
-                console.error(wrap('[]', 'mister pack', chalk.bold.red), e)
+                console.error(wrap('[]', packageName, chalk.bold.red), e)
                 this.packageManager.restorePackagePjson(this.args, packageName);
                 throw e;
             });
@@ -155,11 +151,11 @@ export default class App {
 
         if (this.args.verbose >= 2) {
             /* tslint:disable-next-line */
-            console.log(wrap('[]', 'do-task', chalk.yellow), 'running', chalk.bold(taskName), 'on', chalk.bold(packageName));
+            console.log(wrap('[]', packageName, chalk.yellow), 'running', chalk.bold(taskName), 'on', chalk.bold(packageName));
         }
 
         try {
-            return runProcess('npm', ['run', taskName], spawnOptions, this.args);
+            return runProcess('npm', ['run', taskName], spawnOptions, this.args, packageName);
         } catch (e) {
             return Promise.reject(e);
         }
@@ -177,14 +173,14 @@ export default class App {
                             return;
                         } else {
                             await this.doTask(packageName, realTask);
-                            this.packageCache.writeTimestampForTask(packageName, realTask);
+                            this.packageCache.isPackageTaskUpToDate(packageName, realTask);
                         }
                     } else {
                         return this.doTask(packageName, realTask);
                     }
                 }).catch(e => {
                     console.log(
-                        wrap('[]', 'do task', chalk.bold.red),
+                        wrap('[]', packageName, chalk.bold.red),
                         'error running',
                         wrap('[]', task, chalk.red),
                         'on',
@@ -218,7 +214,7 @@ export default class App {
 
         if (this.verbosity >= 1) {
             /* tslint:disable-next-line */
-            console.log(wrap('[]', 'mister zip'), 'created', chalk.bold.green(shortName));
+            console.log(wrap('[]', packageName), 'created', chalk.bold.green(shortName));
         }
         this.packageCache.writeTimestampForCommand(packageName, 'zip');
     }

--- a/src/lib/App/App.ts
+++ b/src/lib/App/App.ts
@@ -182,8 +182,8 @@ export default class App {
                     } else {
                         return this.doTask(packageName, realTask);
                     }
-                }); }
-            ,accum);
+                });
+            }, accum);
         }, Promise.resolve());
     }
 

--- a/src/lib/App/App.ts
+++ b/src/lib/App/App.ts
@@ -182,6 +182,15 @@ export default class App {
                     } else {
                         return this.doTask(packageName, realTask);
                     }
+                }).catch(e => {
+                    console.log(
+                        wrap('[]', 'do task', chalk.bold.red),
+                        'error running',
+                        wrap('[]', task, chalk.red),
+                        'on',
+                        wrap('[]', packageName, chalk.red)
+                        );
+                    throw e;
                 });
             }, accum);
         }, Promise.resolve());

--- a/src/lib/App/App.ts
+++ b/src/lib/App/App.ts
@@ -181,13 +181,15 @@ export default class App {
                         this.packageCache.writeTimestampForTask(packageName, realTask);
                     }
                 }).catch(e => {
-                    console.log(
-                        wrap('[]', packageName, chalk.bold.red),
-                        'error running',
-                        wrap('[]', task, chalk.red),
-                        'on',
-                        wrap('[]', packageName, chalk.red)
-                        );
+                    if (this.args.verbose) {
+                        console.log(
+                            wrap('[]', packageName, chalk.bold.red),
+                            'error running',
+                            wrap('[]', task, chalk.red),
+                            'on',
+                            wrap('[]', packageName, chalk.red)
+                            );
+                    }
                     throw e;
                 });
             }, accum);

--- a/src/lib/App/App.ts
+++ b/src/lib/App/App.ts
@@ -171,7 +171,7 @@ export default class App {
             return tasks.reduce((a: any, task) => {
                 return a.then(async () => {
                     const realTask = task.replace(/^\!/, '');
-                    const checkCache = task.substring(0, 1) === '!';
+                    const checkCache = task.substring(0, 1) !== '!';
                     if (checkCache) {
                         if (this.packageCache.isPackageTaskUpToDate(packageName, realTask)) {
                             return;

--- a/src/lib/App/App.ts
+++ b/src/lib/App/App.ts
@@ -173,10 +173,11 @@ export default class App {
                             return;
                         } else {
                             await this.doTask(packageName, realTask);
-                            this.packageCache.isPackageTaskUpToDate(packageName, realTask);
+                            this.packageCache.writeTimestampForTask(packageName, realTask);
                         }
                     } else {
-                        return this.doTask(packageName, realTask);
+                        await this.doTask(packageName, realTask);
+                        this.packageCache.writeTimestampForTask(packageName, realTask);
                     }
                 }).catch(e => {
                     console.log(

--- a/src/lib/App/App.ts
+++ b/src/lib/App/App.ts
@@ -6,8 +6,8 @@ import chalk from 'chalk';
 import { sync as rimraf } from 'rimraf';
 import { Argv } from 'yargs';
 
-import normalizeArgs from '../normalize-args';
 import moveFile from '../move-file';
+import normalizeArgs from '../normalize-args';
 import wrap from '../output/wrap';
 import runProcess from '../run-process';
 import npmTgzToZip from '../stream/npm-tgz-to-zip';
@@ -182,6 +182,7 @@ export default class App {
                     }
                 }).catch(e => {
                     if (this.args.verbose) {
+                        /* tslint:disable-next-line:no-console */
                         console.log(
                             wrap('[]', packageName, chalk.bold.red),
                             'error running',

--- a/src/lib/PackageCache/PackageCache.ts
+++ b/src/lib/PackageCache/PackageCache.ts
@@ -374,9 +374,6 @@ export default class PackageCache {
     ) {
         const time = timestamp || new Date();
         const cache = this.getCache();
-        if (this.verbosity >= 3) {
-            console.log(cache);
-        }
         const key = `${thing}Timestamps`;
         if (!cache.hasOwnProperty("packages")) {
             cache.packages = {};

--- a/src/lib/PackageCache/PackageCache.ts
+++ b/src/lib/PackageCache/PackageCache.ts
@@ -126,12 +126,7 @@ export default class PackageCache {
                 if (this.verbosity >= 2) {
                     // tslint:disable-next-line:no-console
                     console.log(
-                        wrap("[]", "mister cache", chalk.gray) +
-                            wrap(
-                                "[]",
-                                `${packageName}:${commandName}`,
-                                chalk.gray
-                            ),
+                        wrap("[]", `${packageName}:${commandName}`, chalk.gray) ,
                         `dependency ${d} is newer than at last command.`
                     );
                 }
@@ -169,12 +164,7 @@ export default class PackageCache {
                 if (this.verbosity >= 2) {
                     // tslint:disable-next-line:no-console
                     console.log(
-                        wrap("[]", "mister cache", chalk.gray) +
-                            wrap(
-                                "[]",
-                                `${packageName} ${thing} ${thingName}`,
-                                chalk.gray
-                            ),
+                        wrap("[]", `${packageName}:${thing}:${thingName}`, chalk.gray),
                         `dependency ${d} is newer than at last command.`
                     );
                 }
@@ -196,7 +186,7 @@ export default class PackageCache {
                     if (this.verbosity >=3) {
                         // tslint:disable-next-line:no-console
                         console.log(
-                            wrap("[]", "mister cache", chalk.gray),
+                            wrap("[]", "mister", chalk.gray),
                             'cache file does not exist'
                         );
                     }
@@ -255,7 +245,7 @@ export default class PackageCache {
         if (this.verbosity >=3) {
             // tslint:disable-next-line:no-console
             console.log(
-                wrap("[]", "mister cache", chalk.gray),
+                wrap("[]", "mister", chalk.gray),
                 'writing cache file'
             );
         }
@@ -288,8 +278,7 @@ export default class PackageCache {
             if (this.verbosity >= 2) {
                 // tslint:disable-next-line:no-console
                 console.log(
-                    wrap("[]", "mister cache", chalk.gray) +
-                        wrap("[]", `${thing} ${thingName}`, chalk.gray),
+                    wrap("[]", `${thing} ${thingName}`, chalk.gray),
                     "has no build timestamp"
                 );
             }
@@ -330,15 +319,6 @@ export default class PackageCache {
                 return false;
             }
             if (stat.mtime >= lastSuccessTime) {
-                if (this.verbosity >= 2) {
-                    // tslint:disable-next-line:no-console
-                    console.log(
-                        f,
-                        "is out of date",
-                        stat.mtime,
-                        lastSuccessTime
-                    );
-                }
                 return true;
             } else {
                 return false;
@@ -349,16 +329,13 @@ export default class PackageCache {
             if (result) {
                 // tslint:disable-next-line:no-console
                 console.log(
-                    wrap("[]", "mister cache", chalk.bold.green) +
-                        wrap("[]", `${packageName} ${thing} ${thingName}`, chalk.green),
+                    wrap("[]", `${packageName}:${thing}:${thingName}`, chalk.bold.green),
                     "is up to date"
                 );
             } else {
                 // tslint:disable-next-line:no-console
                 console.log(
-                    wrap("[]", "mister cache", chalk.bold.yellow) +
-                        wrap("[]", `${packageName} ${thing} ${thingName}`, chalk.yellow),
-                    packageName,
+                    wrap("[]", `${packageName}:${thing}:${thingName}`, chalk.bold.yellow),
                     "is out of date"
                 );
             }
@@ -407,10 +384,10 @@ export default class PackageCache {
     // Migrations
 
     private migrate_1_0_0__to__1_0_1() {
-        if (this.verbosity >=3) {
+        if (this.verbosity) {
             // tslint:disable-next-line:no-console
             console.log(
-                wrap("[]", "mister cache", chalk.gray),
+                wrap("[]", "mister", chalk.green),
                 'migrating cache file from v1.0.0 to v1.0.1'
             );
         }

--- a/src/lib/PackageCache/PackageCache.ts
+++ b/src/lib/PackageCache/PackageCache.ts
@@ -273,7 +273,7 @@ export default class PackageCache {
         if (this.verbosity >= 3) {
             // tslint:disable-next-line:no-console
             console.log(
-                wrap("[]", `${thing} ${thingName}`, chalk.gray),
+                wrap("[]", `${packageName}:${thing}:${thingName}`, chalk.gray),
                 "Checking if up to date"
             );
         }
@@ -281,7 +281,7 @@ export default class PackageCache {
             if (this.verbosity) {
                 // tslint:disable-next-line:no-console
                 console.log(
-                    wrap("[]", `${packageName} ${thing} ${thingName}`, chalk.gray),
+                    wrap("[]", `${packageName}:${thing}:${thingName}`, chalk.gray),
                     "has no cache timestamp"
                 );
             }
@@ -379,7 +379,10 @@ export default class PackageCache {
             if (!cache.packages[packageName].dependencies.hasOwnProperty(d)) {
                 cache.packages[packageName].dependencies[d] = {}
             }
-            cache.packages[packageName].dependencies[d][key] = time;
+            if (!cache.packages[packageName].dependencies[d].hasOwnProperty(key)) {
+                cache.packages[packageName].dependencies[d][key] = {};
+            }
+            cache.packages[packageName].dependencies[d][key][thingName] = time;
         })
         this.flushFile(cache);
     }

--- a/src/lib/PackageCache/PackageCache.ts
+++ b/src/lib/PackageCache/PackageCache.ts
@@ -122,7 +122,7 @@ export default class PackageCache {
             const refTime =
                 cache.packages[packageName].dependencies[d][commandName];
 
-            if (depTimestamp > refTime) {
+            if (depTimestamp > currentTimestamp) {
                 if (this.verbosity >= 2) {
                     // tslint:disable-next-line:no-console
                     console.log(

--- a/src/lib/PackageCache/PackageCache.ts
+++ b/src/lib/PackageCache/PackageCache.ts
@@ -193,8 +193,12 @@ export default class PackageCache {
                         fs.readFileSync(this.cacheFilePath, "utf8")
                     );
                 } else {
-                    if (this.verbosity >= 2) {
-                        console.log(this.cacheFilePath, "does not exist"); // tslint:disable-line:no-console
+                    if (this.verbosity >=3) {
+                        // tslint:disable-next-line:no-console
+                        console.log(
+                            wrap("[]", "mister cache", chalk.gray),
+                            'cache file does not exist'
+                        );
                     }
                     this.buildCache = {
                         packages: {},
@@ -203,7 +207,8 @@ export default class PackageCache {
                 }
             } catch (e) {
                 if (this.verbosity >= 2) {
-                    console.log(e); // tslint:disable-line:no-console
+                    // tslint:disable-next-line no-console
+                    console.log(e);
                 }
                 this.buildCache = {
                     packages: {},
@@ -246,6 +251,13 @@ export default class PackageCache {
     private flushFile(newCache) {
         if (!fs.existsSync(path.dirname(this.cacheFilePath))) {
             fs.mkdirSync(path.dirname(this.cacheFilePath));
+        }
+        if (this.verbosity >=3) {
+            // tslint:disable-next-line:no-console
+            console.log(
+                wrap("[]", "mister cache", chalk.gray),
+                'writing cache file'
+            );
         }
         fs.writeFileSync(
             this.cacheFilePath,
@@ -362,6 +374,9 @@ export default class PackageCache {
     ) {
         const time = timestamp || new Date();
         const cache = this.getCache();
+        if (this.verbosity >= 3) {
+            console.log(cache);
+        }
         const key = `${thing}Timestamps`;
         if (!cache.hasOwnProperty("packages")) {
             cache.packages = {};
@@ -369,9 +384,12 @@ export default class PackageCache {
 
         if (!cache.packages.hasOwnProperty(packageName)) {
             cache.packages[packageName] = {
-                commandTimestamps: {},
                 dependencies: {}
             };
+        }
+
+        if (!cache.packages[packageName].hasOwnProperty(key)) {
+            cache.packages[packageName][key] = {};
         }
 
         cache.packages[packageName][key][thingName] = time;
@@ -392,6 +410,13 @@ export default class PackageCache {
     // Migrations
 
     private migrate_1_0_0__to__1_0_1() {
+        if (this.verbosity >=3) {
+            // tslint:disable-next-line:no-console
+            console.log(
+                wrap("[]", "mister cache", chalk.gray),
+                'migrating cache file from v1.0.0 to v1.0.1'
+            );
+        }
         // First, fix the keys
         Object.keys(this.buildCache.packages).forEach(p => {
             if (this.buildCache.packages[p].hasOwnProperty('dependencies')) {

--- a/src/lib/PackageCache/PackageCache.ts
+++ b/src/lib/PackageCache/PackageCache.ts
@@ -211,6 +211,10 @@ export default class PackageCache {
         if (this.buildCache.version === '1.0.0') {
             this.migrate_1_0_0__to__1_0_1();
         }
+
+        if (this.buildCache.version !== '1.0.1') {
+            throw new Error(`No upgrade path from given cache version '${this.buildCache.version}' to '1.0.1'`)
+        }
         return this.buildCache;
     }
 

--- a/src/lib/PackageCache/PackageCache.ts
+++ b/src/lib/PackageCache/PackageCache.ts
@@ -251,7 +251,7 @@ export default class PackageCache {
         }
         fs.writeFileSync(
             this.cacheFilePath,
-            JSON.stringify(newCache),
+            JSON.stringify(newCache, null, 2),
             "utf8"
         );
         this.buildCache = newCache;
@@ -272,14 +272,17 @@ export default class PackageCache {
     private isPackageThingUpToDate(packageName: string, thing: string, thingName: string) {
         if (this.verbosity >= 3) {
             // tslint:disable-next-line:no-console
-            console.log('Checking if', thing, thingName, 'is up to date for', packageName)
+            console.log(
+                wrap("[]", `${thing} ${thingName}`, chalk.gray),
+                "Checking if up to date"
+            );
         }
         if (!this.doesThingTimestampExist(packageName, thing, thingName)) {
-            if (this.verbosity >= 2) {
+            if (this.verbosity) {
                 // tslint:disable-next-line:no-console
                 console.log(
-                    wrap("[]", `${thing} ${thingName}`, chalk.gray),
-                    "has no build timestamp"
+                    wrap("[]", `${packageName} ${thing} ${thingName}`, chalk.gray),
+                    "has no cache timestamp"
                 );
             }
             return false;
@@ -408,6 +411,7 @@ export default class PackageCache {
             }
         });
 
-        // Now, fix the dates.
+        this.buildCache.version = '1.0.1';
+        this.flushFile(this.buildCache);
     }
 }

--- a/src/lib/PackageCache/__tests__/fixture1/.mister/cache.json
+++ b/src/lib/PackageCache/__tests__/fixture1/.mister/cache.json
@@ -1,4 +1,5 @@
 {
+    "version": "1.0.0",
     "packages": {
         "@test/package3": {
             "commandTimestamps": {"build":  "2018-06-15T19:34:42.887Z"}

--- a/src/lib/PackageCache/__tests__/fixture3/.mister/cache.json
+++ b/src/lib/PackageCache/__tests__/fixture3/.mister/cache.json
@@ -1,0 +1,29 @@
+{
+    "version": "1.0.0",
+    "packages": {
+        "@config/get-db": {
+            "commandTimestamps": {
+                "pack": "2018-09-20T22:09:51.262Z"
+            },
+            "dependencies": {}
+        },
+        "@config/get-ssm-params": {
+            "commandTimestamps": {
+                "pack": "2018-09-21T18:57:31.382Z"
+            },
+            "dependencies": {}
+        },
+        "@lambda/test-fn": {
+            "commandTimestamps": {
+                "pack": "2018-09-21T18:57:47.749Z",
+                "zip": "2018-09-21T18:57:48.287Z"
+            },
+            "dependencies": {
+                "@config/get-ssm-params": {
+                    "pack": "2018-09-21T18:57:47.749Z",
+                    "zip": "2018-09-21T18:57:48.287Z"
+                }
+            }
+        }
+    }
+}

--- a/src/lib/PackageCache/__tests__/fixture3/.mister/cache.json
+++ b/src/lib/PackageCache/__tests__/fixture3/.mister/cache.json
@@ -1,29 +1,32 @@
 {
-    "version": "1.0.0",
-    "packages": {
-        "@config/get-db": {
-            "commandTimestamps": {
-                "pack": "2018-09-20T22:09:51.262Z"
-            },
-            "dependencies": {}
-        },
+  "version": "1.0.1",
+  "packages": {
+    "@config/get-db": {
+      "commandTimestamps": {
+        "pack": "2018-09-20T22:09:51.262Z"
+      },
+      "dependencies": {}
+    },
+    "@config/get-ssm-params": {
+      "commandTimestamps": {
+        "pack": "2018-09-21T18:57:31.382Z"
+      },
+      "dependencies": {}
+    },
+    "@lambda/test-fn": {
+      "commandTimestamps": {
+        "pack": "2018-09-21T18:57:47.749Z",
+        "zip": "2018-09-21T18:57:48.287Z"
+      },
+      "dependencies": {
         "@config/get-ssm-params": {
-            "commandTimestamps": {
-                "pack": "2018-09-21T18:57:31.382Z"
-            },
-            "dependencies": {}
-        },
-        "@lambda/test-fn": {
-            "commandTimestamps": {
-                "pack": "2018-09-21T18:57:47.749Z",
-                "zip": "2018-09-21T18:57:48.287Z"
-            },
-            "dependencies": {
-                "@config/get-ssm-params": {
-                    "pack": "2018-09-21T18:57:47.749Z",
-                    "zip": "2018-09-21T18:57:48.287Z"
-                }
-            }
+          "commandTimestamps": {
+            "pack": "2018-09-21T18:57:47.749Z",
+            "zip": "2018-09-21T18:57:48.287Z"
+          },
+          "taskTimestamps": {}
         }
+      }
     }
+  }
 }

--- a/src/lib/PackageCache/__tests__/fixture3/package.json
+++ b/src/lib/PackageCache/__tests__/fixture3/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "test-migration",
+    "version": "1.0.1",
+    "description": "Test migration from 1.0.0 to 1.0.1"
+
+}

--- a/src/lib/PackageCache/__tests__/fixture3/packages/node_modules/@config/get-db/package.json
+++ b/src/lib/PackageCache/__tests__/fixture3/packages/node_modules/@config/get-db/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "@config/get-db",
+    "main": "index.js"
+}

--- a/src/lib/PackageCache/__tests__/fixture3/packages/node_modules/@config/get-ssm-params/package.json
+++ b/src/lib/PackageCache/__tests__/fixture3/packages/node_modules/@config/get-ssm-params/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "@config/get-ssm-params",
+    "main": "index.js"
+}

--- a/src/lib/PackageCache/__tests__/fixture3/packages/node_modules/@lambda/test-fn/package.json
+++ b/src/lib/PackageCache/__tests__/fixture3/packages/node_modules/@lambda/test-fn/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "@lambda/test-fn",
+    "main": "index.js",
+    "dependencies": {
+        "@config/get-db": "1.0.0",
+        "@config/get-ssm-params": "1.0.0"
+    },
+    "bundledDependencies": [
+        "@config/get-db",
+        "@config/get-ssm-params"
+    ]
+}

--- a/src/lib/PackageCache/__tests__/migrate-to-1.0.1.spec.ts
+++ b/src/lib/PackageCache/__tests__/migrate-to-1.0.1.spec.ts
@@ -1,0 +1,28 @@
+import * as path from 'path';
+
+import test from 'ava';
+
+import PackageManager from '../../PackageManager';
+import PackageCache from '../PackageCache';
+
+const CWD = path.resolve(__dirname, 'fixture3');
+
+test.before(() => {
+    process.chdir(CWD);
+});
+
+test('Migrate from 1.0.0 to 1.0.1', (t) => {
+    const m = new PackageManager();
+    const c = new PackageCache(m);
+
+    const newCache = c.getCache();
+    const p = newCache.get('packages');
+
+    t.truthy(p.has('@lambda/test-fn'));
+
+    const testFnDeps = p.get('@lambda/test-fn').get('dependencies');
+    t.truthy(testFnDeps.has('@config/get-ssm-params'));
+    t.truthy(testFnDeps.get('@config/get-ssm-params').has('commandTimestamps'));
+    t.truthy(testFnDeps.get('@config/get-ssm-params').get('commandTimestamps').has('pack'))
+    t.is(testFnDeps.get('@config/get-ssm-params').get('commandTimestamps').get('pack'), new Date('2018-09-21T18:57:47.749Z'))
+});

--- a/src/lib/PackageCache/__tests__/migrate-to-1.0.1.spec.ts
+++ b/src/lib/PackageCache/__tests__/migrate-to-1.0.1.spec.ts
@@ -16,13 +16,9 @@ test('Migrate from 1.0.0 to 1.0.1', (t) => {
     const c = new PackageCache(m);
 
     const newCache = c.getCache();
-    const p = newCache.get('packages');
-
-    t.truthy(p.has('@lambda/test-fn'));
-
-    const testFnDeps = p.get('@lambda/test-fn').get('dependencies');
-    t.truthy(testFnDeps.has('@config/get-ssm-params'));
-    t.truthy(testFnDeps.get('@config/get-ssm-params').has('commandTimestamps'));
-    t.truthy(testFnDeps.get('@config/get-ssm-params').get('commandTimestamps').has('pack'))
-    t.is(testFnDeps.get('@config/get-ssm-params').get('commandTimestamps').get('pack'), new Date('2018-09-21T18:57:47.749Z'))
+    t.truthy(newCache.packages.hasOwnProperty('@lambda/test-fn'));
+    t.truthy(newCache.packages['@lambda/test-fn'].dependencies.hasOwnProperty('@config/get-ssm-params'));
+    t.truthy(newCache.packages['@lambda/test-fn'].dependencies['@config/get-ssm-params'].hasOwnProperty('commandTimestamps'));
+    t.truthy(newCache.packages['@lambda/test-fn'].dependencies['@config/get-ssm-params'].commandTimestamps.hasOwnProperty('pack'))
+    t.is(newCache.packages['@lambda/test-fn'].dependencies['@config/get-ssm-params'].commandTimestamps.pack, '2018-09-21T18:57:47.749Z');
 });

--- a/src/lib/PackageManager/PackageManager.ts
+++ b/src/lib/PackageManager/PackageManager.ts
@@ -122,9 +122,16 @@ export default class PackageManager {
     }
 
     public getMatchingPackageTasks(packageName, tasks?: string[]) {
-        return this.getPackageTasks(packageName).filter((taskName) =>
-            tasks.find((t) => t.replace(/^\!/, '') === taskName)
-        );
+        // return this.getPackageTasks(packageName).filter((taskName) =>
+        //     tasks.find((t) => t.replace(/^\!/, '') === taskName)
+        // );
+        return this.getPackageTasks(packageName).reduce((res, taskName) => {
+            const found = tasks.find((t) => t.replace(/^\!/, '') === taskName);
+            if (found) {
+                res.push(found)
+            }
+            return res;
+        }, []);
     }
 
     public getMonorepoPjson(): PjsonFile {

--- a/src/lib/PackageManager/PackageManager.ts
+++ b/src/lib/PackageManager/PackageManager.ts
@@ -123,7 +123,7 @@ export default class PackageManager {
 
     public getMatchingPackageTasks(packageName, tasks?: string[]) {
         return this.getPackageTasks(packageName).filter((taskName) =>
-            tasks.find((t) => t === taskName),
+            tasks.find((t) => t.replace(/^\!/, '') === taskName)
         );
     }
 

--- a/src/lib/PackageManager/PackageManager.ts
+++ b/src/lib/PackageManager/PackageManager.ts
@@ -281,7 +281,11 @@ export default class PackageManager {
         const packageDir = this.getPackageDir(packageName);
         const spawnOptions: SpawnOptions = {
             cwd: packageDir,
-            env: Object.assign({}, process.env),
+            env: Object.assign({}, {
+                MISTER_PACKAGE: packageName,
+                MISTER_PACKAGE_PATH: packageDir,
+                MISTER_ROOT: path.resolve(process.cwd()),
+            }, process.env),
         };
 
         /* istanbul ignore if */

--- a/src/lib/__tests__/run-process.spec.ts
+++ b/src/lib/__tests__/run-process.spec.ts
@@ -3,6 +3,6 @@ import test from 'ava';
 import runProcess from '../run-process';
 
 test('run-process should fail with fun', async (t) => {
-    const err = await t.throwsAsync(runProcess('npm', ['run', 'notask'], {}, {}));
+    const err = await t.throwsAsync(runProcess('npm', ['run', 'notask'], {}, {quiet: true}));
     t.truthy(err);
 });

--- a/src/lib/__tests__/write-cache.spec.ts
+++ b/src/lib/__tests__/write-cache.spec.ts
@@ -28,6 +28,7 @@ test.after(() => {
 test('Verify that cache creation works', (t) => {
     const args = {
         packages: ['@test-server/api'],
+        quiet: true
     };
     return runProcess('npm', ['install', '--skip-package-lock'], {
         cwd: path.join(CWD),

--- a/src/lib/normalize-args.ts
+++ b/src/lib/normalize-args.ts
@@ -1,0 +1,13 @@
+import { Argv } from 'yargs';
+
+export interface PossibleArgs extends Argv {
+    verbose?: number;
+    quiet?: boolean;
+}
+
+export default function normalizeArgs(args: PossibleArgs) {
+    if (args.quiet) {
+        args.verbose = 0;
+    }
+    return args;
+}

--- a/src/lib/run-process.ts
+++ b/src/lib/run-process.ts
@@ -38,8 +38,12 @@ export default function runProcess(command: string, args: string[], options: Spa
 
             runProc.on('exit', (code: number, signal: string) => {
                 if (code !== 0) {
-                    const e = new Error(`${wrap('[]', 'run-process', chalk.bold.red)} failed: ${command} ${args.join(' ')}\nOutput\n======\n\n${errBuffer.toString()}`);
-                    e.stack = errBuffer.toString();
+                    const e = new Error(`${wrap('[]', 'run-process', chalk.bold.red)} failed: ${command} ${args.join(' ')}\nOutput\n======\n\n${errBuffer && errBuffer.toString()}`);
+
+                    if (errBuffer) {
+                        e.stack = errBuffer.toString();
+                    }
+
                     reject(e);
                 } else {
                     resolve();

--- a/src/lib/run-process.ts
+++ b/src/lib/run-process.ts
@@ -48,12 +48,17 @@ export default function runProcess(command: string, args: string[], options: Spa
             }
 
             runProc.on('error', (e) => {
+                errBuffer.toString().split(EOL).forEach(l => {
+                    /* tslint:disable-next-line no-console */
+                    console.log(wrap('[]', 'run-process', chalk.gray), chalk.red(l));
+                });
                 reject(e);
             });
 
             runProc.on('exit', (code: number, signal: string) => {
                 if (code !== 0) {
-                    const e = new Error(`${wrap('[]', 'run-process', chalk.bold.red)} failed: ${command} ${args.join(' ')}\nOutput\n======\n\n${errBuffer && errBuffer.toString()}`);
+                    const e = new Error(
+                        `${wrap('[]', 'run-process', chalk.bold.red)} failed: ${command} ${args.join(' ')}\nOutput\n======\n\n${errBuffer && errBuffer.toString()}`);
 
                     if (errBuffer) {
                         e.stack = errBuffer.toString();

--- a/src/lib/run-process.ts
+++ b/src/lib/run-process.ts
@@ -52,10 +52,12 @@ export default function runProcess(command: string, args: string[], options: Spa
             }
 
             runProc.on('error', (e) => {
-                errBuffer.toString().split(EOL).forEach(l => {
-                    /* tslint:disable-next-line no-console */
-                    console.log(wrap('[]', logPrefix || 'run-process', chalk.bold.red), l);
-                });
+                if (errBuffer && !argv.quiet) {
+                    errBuffer.toString().split(EOL).forEach(l => {
+                        /* tslint:disable-next-line no-console */
+                        console.log(wrap('[]', logPrefix || 'run-process', chalk.bold.red), l);
+                    });
+                }
                 reject(e);
             });
 
@@ -66,11 +68,13 @@ export default function runProcess(command: string, args: string[], options: Spa
 
                     if (errBuffer) {
                         e.stack = errBuffer.toString();
+                        if (!argv.quiet) {
+                            errBuffer.toString().split(EOL).forEach(l => {
+                                /* tslint:disable-next-line no-console */
+                                console.log(wrap('[]', logPrefix || 'run-process', chalk.bold.red), l);
+                            });
+                        }
                     }
-                    errBuffer.toString().split(EOL).forEach(l => {
-                        /* tslint:disable-next-line no-console */
-                        console.log(wrap('[]', logPrefix || 'run-process', chalk.bold.red), l);
-                    });
                     reject(e);
                 } else {
                     resolve();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,19 @@
 {
     "compilerOptions": {
-        "target": "esnext",
+        "target": "es6",
         "module": "commonjs",
         "outDir": "dist",
         "esModuleInterop": false,
         "allowSyntheticDefaultImports": false,
         "declaration": true,
-        "inlineSourceMap": true
+        "inlineSourceMap": true,
+        "removeComments": false
     },
     "include": [
         "src/**/*.ts"
     ],
     "exclude": [
         "src/**/__tests__/**"
-    ]
+    ],
+
 }


### PR DESCRIPTION
All package tasks will be cached now, unless you prefix with `!`, such as in `mister do-all clean build !test !coverage` - `clean` will only happen on a package (and it's dependents) if files have changed, as will `build`.  `test` and `coverage` will always be run on all packages.

- Updates the cache version to `1.0.1` and provides a migration path for the cache file.
- Adds tests for the cache file migration.
- Seriously cleans up logging.
- Always display `stdout/stderr` from `run-process` when a subprocess errors or exits with a non-zero status code.

Implements #4 